### PR TITLE
chore: enable commitlint in GitHub Actions

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -1,0 +1,5 @@
+extends:
+  - "@commitlint/config-conventional"
+rules:
+  # so that long URLs e.g. GitHub can be included in the commit message body
+  body-max-line-length: [2, "always", ["Infinity"]]

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,0 +1,17 @@
+# .github/workflows/commitlint.yaml
+# Copyright 2025 Keith Maxwell
+# SPDX-License-Identifier: CC0-1.0
+
+on: # yamllint disable-line rule:truthy
+  pull_request: { branches: [main] }
+  workflow_dispatch:
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - run:
+          podman run --volume=$PWD:/src:z --workdir=/src commitlint/commitlint
+          --verbose --from=origin/main --to=HEAD


### PR DESCRIPTION
Use a container image because:

1. Adding a package.json file causes Deno to always use a node_modules directory and

2. commitlint's mechanism for importing configuration presets isn't suitable to run with deno or `npm exec`.
