### PR TITLE
Add --no-config to avoid a warning

### DIFF
--- a/dislodge/README.md
+++ b/dislodge/README.md
@@ -4,7 +4,7 @@ Opposite of <https://github.com/zakhenry/embedme>.
 
 Command to install from GitHub:
 
-    deno install --global --allow-read --allow-write \
+    deno install --global --allow-read --allow-write --no-config \
         https://raw.githubusercontent.com/maxwell-k/mdcommands/main/dislodge/main.ts
 
 <!--

--- a/mdcommands/README.md
+++ b/mdcommands/README.md
@@ -20,7 +20,7 @@
 
 Command to install from GitHub:
 
-    deno install --global --allow-read \
+    deno install --global --allow-read --no-config \
         https://raw.githubusercontent.com/maxwell-k/mdcommands/main/mdcommands/main.ts
 
 Command to print code blocks from [example.md](./example.md):


### PR DESCRIPTION
Before this change the install commands show the warning below:

    Warning discovered config file will be ignored in the installed command. Use the --config flag if you wish to include it.
