### PR TITLE
Review CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,3 +40,12 @@ jobs:
       - run:
           podman run "--volume=$PWD:/src:z" --workdir=/src commitlint/commitlint
           --verbose --from=origin/main --to=HEAD
+  zizmor:
+    runs-on: ubuntu-24.04
+    # https://github.com/zizmorcore/zizmor-action#permissions
+    permissions: { security-events: write }
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with: { persist-credentials: false }
+      # yamllint disable-line rule:line-length
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with: { persist-credentials: false }
-      - uses: denoland/setup-deno@v2
+      # yamllint disable-line rule:line-length
+      - uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
       - run: deno --version
       - run: deno task all
       - run: git diff --exit-code # changes cause this job to fail

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,6 +7,8 @@ on: # yamllint disable-line rule:truthy
   pull_request: { branches: [main] }
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with: { persist-credentials: false }
       - uses: denoland/setup-deno@v2
       - run: deno --version
       - run: deno task all
@@ -29,7 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with: { fetch-depth: 0 }
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - run:
           podman run "--volume=$PWD:/src:z" --workdir=/src commitlint/commitlint
           --verbose --from=origin/main --to=HEAD

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,8 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with: { path: coverage/html/ }
-      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
+      # yamllint disable-line rule:line-length
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with: { enable-cache: false }
       - run: uv tool run reuse lint
   renovate-config-validator:


### PR DESCRIPTION
- **fix: avoid persisting credentials in GitHub workflow run**
- **fix: adapt to astral's immutable release policy for uv**
- **fix: adopt principle of least privilege in CI**
- **fix: pin to specific version of deno**
- **chore: add a zizmor job on CI**
